### PR TITLE
Miruro and storage handling improvements

### DIFF
--- a/chrome-manifest.json
+++ b/chrome-manifest.json
@@ -23,6 +23,8 @@
       "resources": ["css/index.css"],
       "matches": [
         "https://hianime.to/*",
+        "https://miruro.tv/*",
+        "https://miruro.tv/*",
         "https://miruro.tv/*"
       ]
     }

--- a/firefox-manifest.json
+++ b/firefox-manifest.json
@@ -21,7 +21,7 @@
   "web_accessible_resources": [
     {
       "resources": ["css/index.css"],
-      "matches": ["https://hianime.to/*", "https://miruro.tv/*"]
+      "matches": ["https://hianime.to/*", "https://miruro.tv/*", "https://miruro.online/*", "https://miruro.to/*"]
     }
   ],
   "browser_specific_settings": {

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,9 @@
       "matches": [
         "https://hianimez.to/*",
         "https://hianime.to/*",
-        "https://miruro.tv/*"
+        "https://miruro.tv/*",
+        "https://miruro.online/*",
+        "https://miruro.to/*"
       ]
     }
   ]

--- a/src/animeSites.ts
+++ b/src/animeSites.ts
@@ -39,12 +39,12 @@ class Miruro implements AnimeSite {
   }
   isOnEpSite(url: string): boolean {
     const epSiteRegEx = new RegExp(
-      /https:\/\/www\.miruro\.tv\/watch\/.+\/episode-\d+/,
+      /https:\/\/(?:www\.)?miruro\.[a-z]+\/watch\/.+(?:\/episode-\d+|\?ep=\d+)/,
     );
     return epSiteRegEx.test(url);
   }
   getEpisode(): number | null {
-    const match = window.location.pathname.match(/\/episode-(\d+)/);
+    const match = window.location.href.match(/(?:\/episode-|\?ep=)(\d+)/);
     if (!match) return null;
     return parseInt(match[1]);
   }
@@ -58,4 +58,6 @@ class Miruro implements AnimeSite {
 export const animeSites = new Map<string, AnimeSite>([
   ["hianime.to", new hianime()],
   ["miruro.tv", new Miruro()],
+  ["miruro.online", new Miruro()],
+  ["miruro.to", new Miruro()],
 ]);

--- a/src/background.ts
+++ b/src/background.ts
@@ -2,7 +2,7 @@ import { animeSites } from "./animeSites";
 import { AnimeMetaData, JimakuEntry, Subs, AnilistObject } from "./types";
 
 let lastProcessedUrl = "";
-let lastDownloadedSubId: number;
+let lastDownloadedKey: string;
 
 async function alreadyDownloaded(id: number, episode: number) {
   const key = `${id}_${episode}`;
@@ -192,9 +192,12 @@ async function downloadSubs(anilistId: number, episode: number) {
       if (chrome.runtime.lastError) {
         return chrome.runtime.lastError.message;
       }
-      lastDownloadedSubId = downloadId;
       if (name.endsWith(".zip") || name.endsWith(".rar")) {
         await markMultipleAsDownloaded(name, anilistId);
+      } else {
+        const key = `${anilistId}_${episode}`;
+        lastDownloadedKey = key;
+        await chrome.storage.local.set({ [key]: downloadId });
       }
     },
   );
@@ -205,14 +208,22 @@ async function removeLastDownloaded() {
   const autoDelete = <boolean>(
     (await chrome.storage.sync.get("autoDelete")).autoDelete
   );
-  if (autoDelete) await chrome.downloads.removeFile(lastDownloadedSubId);
+  if (autoDelete)  {
+    await chrome.storage.local.get(lastDownloadedKey, async (result) => {
+      if (Object.keys(result).length === 0) return;
+      const downloadId = result[lastDownloadedKey];
+      if (downloadId === true) return;
+      await chrome.downloads.removeFile(downloadId);
+      await chrome.storage.local.remove(lastDownloadedKey);
+    });
+  }
 }
 
 chrome.webNavigation.onHistoryStateUpdated.addListener((details) => {
   if (details.frameId !== 0) return;
   chrome.tabs.get(details.tabId, async (tab) => {
     if (tab.url !== details.url || lastProcessedUrl === details.url) return;
-    if (lastDownloadedSubId) await removeLastDownloaded();
+    await removeLastDownloaded();
     lastProcessedUrl = tab.url;
     const animeSiteKey = getAnimeSiteKey(tab.url);
     if (!animeSiteKey) return;

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,7 +1,7 @@
 import { animeSites } from "./animeSites";
 import { AnimeMetaData, JimakuEntry, Subs, AnilistObject } from "./types";
 
-const lasDownloadedKeyName = "lastDownloadedKey";
+const lastDownloadedKeyName = "lastDownloadedKey";
 let lastProcessedUrl = "";
 
 async function alreadyDownloaded(id: number, episode: number) {
@@ -196,8 +196,10 @@ async function downloadSubs(anilistId: number, episode: number) {
         await markMultipleAsDownloaded(name, anilistId);
       } else {
         const key = `${anilistId}_${episode}`;
-        await chrome.storage.local.set({ [lasDownloadedKeyName]: key });
-        await chrome.storage.local.set({ [key]: downloadId });
+        await chrome.storage.local.set({
+          [lastDownloadedKeyName]: key,
+          [key]: downloadId,
+        });
       }
     },
   );
@@ -210,8 +212,8 @@ async function removeLastDownloaded() {
   );
   if (autoDelete)  {
     let lastDownloadedKey: string;
-    lastDownloadedKey = (await chrome.storage.local.get(lasDownloadedKeyName))[lasDownloadedKeyName];
-    await chrome.storage.local.get(lastDownloadedKey, async (result) => {
+    lastDownloadedKey = (await chrome.storage.local.get(lastDownloadedKeyName))[lastDownloadedKeyName];
+    chrome.storage.local.get(lastDownloadedKey, async (result) => {
       if (Object.keys(result).length === 0) return;
       const downloadId = result[lastDownloadedKey];
       if (downloadId === true) return;

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,8 +1,8 @@
 import { animeSites } from "./animeSites";
 import { AnimeMetaData, JimakuEntry, Subs, AnilistObject } from "./types";
 
+const lasDownloadedKeyName = "lastDownloadedKey";
 let lastProcessedUrl = "";
-let lastDownloadedKey: string;
 
 async function alreadyDownloaded(id: number, episode: number) {
   const key = `${id}_${episode}`;
@@ -196,7 +196,7 @@ async function downloadSubs(anilistId: number, episode: number) {
         await markMultipleAsDownloaded(name, anilistId);
       } else {
         const key = `${anilistId}_${episode}`;
-        lastDownloadedKey = key;
+        await chrome.storage.local.set({ [lasDownloadedKeyName]: key });
         await chrome.storage.local.set({ [key]: downloadId });
       }
     },
@@ -209,6 +209,8 @@ async function removeLastDownloaded() {
     (await chrome.storage.sync.get("autoDelete")).autoDelete
   );
   if (autoDelete)  {
+    let lastDownloadedKey: string;
+    lastDownloadedKey = (await chrome.storage.local.get(lasDownloadedKeyName))[lasDownloadedKeyName];
     await chrome.storage.local.get(lastDownloadedKey, async (result) => {
       if (Object.keys(result).length === 0) return;
       const downloadId = result[lastDownloadedKey];


### PR DESCRIPTION
Hey, I tried to make some improvements to your project. Please take a look at them an consider merging them.
The changes include:

1. Adding more miruro mirrors (miruro.online and miruro.to)
2. Modified the RegExp strings added in your latest commit to account for both ways Miruro handles URLs.
3. Changed the way how the extension saves which subs have already been downloaded mainly in order to make the auto deletion feature more usable (it can now redownload auto deleted subs for example).
